### PR TITLE
Ensure JupyterLab is installed in coiled conda environment

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -11,10 +11,11 @@ USER $NB_USER
 
 RUN conda create -y -n coiled \
     -c conda-forge \
+    jupyterlab=3 \
     ipywidgets \
-    dask-labextension==3.0.0 \
+    dask-labextension>=5 \
     jupyter-offlinenotebook \
-    && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension@3.0.0 jupyter-offlinenotebook \
+    && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyter-offlinenotebook \
     && conda clean -tipsy \
     && jupyter lab clean \
     && jlpm cache clean \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:lab-2.2.9
+FROM jupyter/base-notebook:lab-3.0.5
 
 USER root
 
@@ -15,7 +15,6 @@ RUN conda create -y -n coiled \
     ipywidgets \
     dask-labextension>=5 \
     jupyter-offlinenotebook \
-    && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyter-offlinenotebook \
     && conda clean -tipsy \
     && jupyter lab clean \
     && jlpm cache clean \


### PR DESCRIPTION
After a debugging session with @FabioRosado, we saw that `jupyterlab` wasn't installed in the `coiled` conda environment. This is an artifact of us recently changing the name of the conda environment we install packages into from `base` to `coiled`. This PR ensures that `jupyterlab` is installed.