### PR TITLE
Use Python 3.8 in notebook image

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -11,8 +11,11 @@ USER $NB_USER
 
 RUN conda create -y -n coiled \
     -c conda-forge \
+    # Dask does not fully support Python 3.9 yet
+    python=3.8 \
     jupyterlab=3 \
     ipywidgets \
+    # Pinning >=5 to be compatible with JupyterLab 3+
     dask-labextension>=5 \
     jupyter-offlinenotebook \
     && conda clean -tipsy \


### PR DESCRIPTION
This PR ensures `coiled/notebook` uses Python 3.8 by default as Dask doesn't yet support Python 3.9. We've also observed some conda environment solve conflicts in our notebook CI builds which this _may_ help resolve. 