### PR TITLE
Include build-essential in dockerfiles so we can use g++, make, etc

### DIFF
--- a/default/Dockerfile
+++ b/default/Dockerfile
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3:4.9.2
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y gcc && \
+    apt-get install -y build-essential && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -3,7 +3,7 @@ FROM jupyter/base-notebook:lab-2.2.9
 USER root
 
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends gcc git \
+    && apt-get install -yq --no-install-recommends build-essential git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes coiled/cloud#1976