### PR TITLE
Install jupyter-related packages with conda

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -13,6 +13,10 @@ RUN conda create -y -n coiled \
     -c conda-forge \
     python=3.9 \
     dask=2021.6.2  \
+    jupyterlab~=3.0 \
+    ipywidgets \
+    dask-labextension \
+    jupyter-offlinenotebook \
     && conda clean -tipsy \
     && find /opt/conda/envs/coiled/ -type f,l -name '*.a' -delete \
     && find /opt/conda/envs/coiled/ -type f,l -name '*.pyc' -delete \
@@ -20,4 +24,3 @@ RUN conda create -y -n coiled \
     && find /opt/conda/envs/coiled/lib/python*/site-packages/bokeh/server/static -type f,l -name '*.js' -not -name '*.min.js' -delete \
     && rm -rf /opt/conda/envs/coiled/pkgs \
     && echo "conda activate coiled" >> ~/.bashrc
-RUN conda run -n coiled --no-capture-output python -m pip install jupyterlab~=3.0.0 ipywidgets dask-labextension jupyter-offlinenotebook


### PR DESCRIPTION
We had previously avoided installing these with conda due to solve issues in #26 . I could no longer reproduce those issues, so reverting to conda. This will allow us to avoid unfortunate mixed-python-version environments that can happen if a user tries to install a different python version in the environment.

cc @jrbourbeau for visibility.